### PR TITLE
Move resources definition to the right place in the deployment

### DIFF
--- a/charts/bitwarden/templates/deployment.yaml
+++ b/charts/bitwarden/templates/deployment.yaml
@@ -44,14 +44,14 @@ spec:
         - mountPath: {{ .Values.storage.path }}
           name: data-storage
         {{ end }}
+        resources:
+          {{- toYaml .Values.deployment.resources | nindent 10 }}
       {{ if .Values.storage.enabled -}}
       volumes:
       - name: data-storage
         persistentVolumeClaim:
          claimName: {{ $fullName }}-pv
       {{ end }}
-      resources:
-        {{- toYaml .Values.deployment.resources | nindent 12 }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Hi, first of all thank you for you work on this chart :)

I used this chart this week-end and had to fixed small things for it to work. I've made a different pull for each point. This is the one regarding the misplacing of the `resources` definition in the deployment.