### PR TITLE
Fixes to make the chart work with Helm3

### DIFF
--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.0"
 description: A Helm chart to install bitwarden_rs
 name: bitwarden
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/Skeen/helm-bitwarden_rs
 maintainers:
 - name: Skeen

--- a/charts/bitwarden/templates/database-backup.yaml
+++ b/charts/bitwarden/templates/database-backup.yaml
@@ -12,16 +12,16 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.backup.schedule | quote }}
+  # Disallow concurrency if writing the same file
+  {{ if .Values.backup.timestamp -}}
+  concurrencyPolicy: Allow
+  {{ else }}
+  concurrencyPolicy: Forbid
+  {{ end }}
   jobTemplate:
     spec:
       template:
         spec:
-          # Disallow concurrency if writing the same file
-          {{ if .Values.backup.timestamp -}}
-          concurrencyPolicy: Allow
-          {{ else }}
-          concurrencyPolicy: Forbid
-          {{ end }}
           containers:
           - name: {{ $fullName }}-database-backup
             image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"

--- a/charts/bitwarden/templates/database-backup.yaml
+++ b/charts/bitwarden/templates/database-backup.yaml
@@ -52,15 +52,15 @@ spec:
             {{- toYaml .Values.backup.resources | nindent 12 }}
           {{- with .Values.backup.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.backup.affinity }}
+          {{- with .Values.backup.affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.backup.tolerations }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backup.tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
-        {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/bitwarden/templates/database-backup.yaml
+++ b/charts/bitwarden/templates/database-backup.yaml
@@ -48,8 +48,10 @@ spec:
             persistentVolumeClaim:
               claimName: {{ $fullName }}-backup-pv
           restartPolicy: OnFailure
+          {{- with .Values.backup.resources }}
           resources:
-            {{- toYaml .Values.backup.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.backup.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/bitwarden/templates/deployment.yaml
+++ b/charts/bitwarden/templates/deployment.yaml
@@ -44,8 +44,10 @@ spec:
         - mountPath: {{ .Values.storage.path }}
           name: data-storage
         {{ end }}
+      {{- with .Values.deployment.resources }}
       resources:
-        {{- toYaml .Values.deployment.resources | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{ if .Values.storage.enabled -}}
       volumes:
       - name: data-storage

--- a/charts/bitwarden/templates/deployment.yaml
+++ b/charts/bitwarden/templates/deployment.yaml
@@ -44,8 +44,8 @@ spec:
         - mountPath: {{ .Values.storage.path }}
           name: data-storage
         {{ end }}
-        resources:
-          {{- toYaml .Values.deployment.resources | nindent 10 }}
+      resources:
+        {{- toYaml .Values.deployment.resources | nindent 8 }}
       {{ if .Values.storage.enabled -}}
       volumes:
       - name: data-storage

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -80,10 +80,10 @@ bitwarden:
 
 deployment:
   # Image used for the deployment
-  # See: https://github.com/mprasil/bitwarden_rs
+  # See: https://www.github.com/dani-garcia/bitwarden_rs
   image:
-    repository: mprasil/bitwarden
-    tag: 1.5.0
+    repository: bitwardenrs/server
+    tag: 1.15.1
     pullPolicy: IfNotPresent
   # Resources, etc, for the deployment pod
   resources: {}


### PR DESCRIPTION
Hi,

It seems Helm3 does some more strict testing of generated manifests against the Kubernetes API, and refuses to install the chart.

This change solves following errors for me (with an empty `backup.resources` in `values.yaml`):

```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].resources): invalid type for io.k8s.api.core.v1.ResourceRequirements: got "boolean", expected "map"
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(CronJob.spec.jobTemplate.spec.template.spec): unknown field "concurrencyPolicy" in io.k8s.api.core.v1.PodSpec
```

In addition, the docker image has been moved to a new entity within the Docker Hub, requiring a small change in `values.yaml`.