### PR TITLE
Update chart to bitwarden_rs 1.16.1

### DIFF
--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.5.0"
+appVersion: "1.16.1"
 description: A Helm chart to install bitwarden_rs
 name: bitwarden
-version: 0.1.2
+version: 0.2.0
 home: https://github.com/Skeen/helm-bitwarden_rs
 maintainers:
 - name: Skeen

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -83,7 +83,7 @@ deployment:
   # See: https://www.github.com/dani-garcia/bitwarden_rs
   image:
     repository: bitwardenrs/server
-    tag: 1.15.1
+    tag: 1.16.1
     pullPolicy: IfNotPresent
   # Resources, etc, for the deployment pod
   resources: {}


### PR DESCRIPTION
Been using this chart for a while, and just got notified a new version of Bitwarden RS is out. This (trivial) commit bumps the image tag, chart version and app version.