### PR TITLE
Fix resources, fix image repository, bump chart, fix CI

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,17 +9,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
         with:
-          install_local_path_provisioner: true
+          version: v3.6.3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Setup chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
 
       - name: Run chart-testing (lint)
-        uses: helm/chart-testing-action@v1.0.0-alpha.2
-        with:
-          command: lint
+        run: ct lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-alpha.2
-        with:
-          command: install
+        run: ct install
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.1
+        uses: helm/chart-releaser-action@v1.2.1
         env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.16.1"
+appVersion: 1.21.0
 description: A Helm chart to install bitwarden_rs
 name: bitwarden
-version: 0.2.1
+version: 0.3.0
 home: https://github.com/Skeen/helm-bitwarden_rs
 maintainers:
 - name: Skeen

--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.16.1"
 description: A Helm chart to install bitwarden_rs
 name: bitwarden
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/Skeen/helm-bitwarden_rs
 maintainers:
 - name: Skeen

--- a/charts/bitwarden/templates/database-backup.yaml
+++ b/charts/bitwarden/templates/database-backup.yaml
@@ -40,6 +40,10 @@ spec:
               name: data-storage
             - mountPath: {{ .Values.backup.path }}
               name: backup-storage
+            {{- with .Values.backup.resources }}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
           volumes:
           - name: data-storage
             persistentVolumeClaim:
@@ -48,10 +52,6 @@ spec:
             persistentVolumeClaim:
               claimName: {{ $fullName }}-backup-pv
           restartPolicy: OnFailure
-          {{- with .Values.backup.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- with .Values.backup.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/bitwarden/templates/deployment.yaml
+++ b/charts/bitwarden/templates/deployment.yaml
@@ -54,9 +54,9 @@ spec:
           name: data-storage
         {{ end }}
       {{- with .Values.deployment.resources }}
-      resources:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{ if .Values.storage.enabled -}}
       volumes:
       - name: data-storage

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -81,8 +81,8 @@ deployment:
   # Image used for the deployment
   # See: https://www.github.com/dani-garcia/bitwarden_rs
   image:
-    repository: bitwardenrs/server
-    tag: 1.16.1
+    repository: vaultwarden/server
+    tag: 1.21.0
     pullPolicy: IfNotPresent
   # Resources, etc, for the deployment pod
   resources: {}


### PR DESCRIPTION
I've been using your chart (thanks for it!) for a while, and noticed there were some small improvements I've fixed:
- The resources were provisioned at pod-level, while (at least on k8s 1.21) it's a property of the container. If I use them with the chart as-is, k8s considers the manifests invalid
- The image repository changed from bitwardenrs to vaultwarden
- The image tag was a bit behind.