### PR TITLE
Improve ingress templating

### DIFF
--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.21.0
 description: A Helm chart to install bitwarden_rs
 name: bitwarden
-version: 0.3.0
+version: 0.3.1
 home: https://github.com/Skeen/helm-bitwarden_rs
 maintainers:
 - name: Skeen

--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.21.0
 description: A Helm chart to install bitwarden_rs
 name: bitwarden
-version: 0.3.1
+version: 0.4.0
 home: https://github.com/Skeen/helm-bitwarden_rs
 maintainers:
 - name: Skeen

--- a/charts/bitwarden/templates/ingress.yaml
+++ b/charts/bitwarden/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "bitwarden.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-ingress
@@ -33,8 +37,15 @@ spec:
 	{{- range $ingressPaths }}
           - path: {{ . }}
             backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+{{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
+{{- end }}
 	{{- end }}
   {{- end }}
 {{- end }}

--- a/charts/bitwarden/templates/ingress.yaml
+++ b/charts/bitwarden/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
   {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -153,6 +153,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ssl-redirect: "true"
+  # className: nginx
   paths:
     - '/'
   hosts:


### PR DESCRIPTION
This PR fixes two things:
- compatibility with v1 ingress (which makes it possible to deploy on 1.22)
- allow optional specification of ingressClassName