### PR TITLE
Websocket and Secret support

### DIFF
--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.21.0
 description: A Helm chart to install bitwarden_rs
 name: bitwarden
-version: 0.4.0
+version: 0.5.0
 home: https://github.com/Skeen/helm-bitwarden_rs
 maintainers:
 - name: Skeen

--- a/charts/bitwarden/templates/NOTES.txt
+++ b/charts/bitwarden/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range $.Values.ingress.paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/bitwarden/templates/deployment.yaml
+++ b/charts/bitwarden/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ $fullName }}-conf
+        {{- if .Values.deployment.secrets }}
+        {{- range .Values.deployment.secrets }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.bitwarden.rocket_port }}

--- a/charts/bitwarden/templates/deployment.yaml
+++ b/charts/bitwarden/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
         - name: http
           containerPort: {{ .Values.bitwarden.rocket_port }}
           protocol: TCP
+        {{- if .Values.bitwarden.websocket_enabled }}
+        - name: ws
+          containerPort: {{ .Values.bitwarden.websocket_port }}
+          protocol: TCP
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /

--- a/charts/bitwarden/templates/ingress.yaml
+++ b/charts/bitwarden/templates/ingress.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "bitwarden.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $newNetworkingAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $newNetworkingAPI }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: extensions/v1beta1
@@ -40,15 +41,15 @@ spec:
 	{{- range $ingressPaths }}
           - path: {{ . }}
             backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $newNetworkingAPI }}
               service:
                 name: {{ $fullName }}
                 port:
                   name: http
-{{- else }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
-{{- end }}
+              {{- end }}
 	{{- end }}
   {{- end }}
 {{- end }}

--- a/charts/bitwarden/templates/ingress.yaml
+++ b/charts/bitwarden/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "bitwarden.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
 {{- $newNetworkingAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $webSocketEnabled := .Values.bitwarden.websocket_enabled }}
 {{- if $newNetworkingAPI }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
@@ -38,7 +39,7 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-	{{- range $ingressPaths }}
+        	{{- range $ingressPaths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:
@@ -51,6 +52,32 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: http
               {{- end }}
-	{{- end }}
+	        {{- end }}
+          {{- if $webSocketEnabled }}
+          - path: /notifications/hub
+            pathType: ImplementationSpecific
+            backend:
+              {{- if $newNetworkingAPI }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: ws
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: ws
+              {{- end }}
+          - path: /notifications/hub/negotiate
+            pathType: ImplementationSpecific
+            backend:
+              {{- if $newNetworkingAPI }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: http
+              {{- end }}
+          {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/bitwarden/templates/ingress.yaml
+++ b/charts/bitwarden/templates/ingress.yaml
@@ -39,7 +39,8 @@ spec:
       http:
         paths:
 	{{- range $ingressPaths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               {{- if $newNetworkingAPI }}
               service:

--- a/charts/bitwarden/templates/service.yaml
+++ b/charts/bitwarden/templates/service.yaml
@@ -15,6 +15,12 @@ spec:
       targetPort: {{ .Values.service.target_port }}
       protocol: TCP
       name: http
+    {{- if .Values.bitwarden.websocket_enabled }}
+    - port: {{ .Values.bitwarden.websocket_port }}
+      targetPort: {{ .Values.bitwarden.websocket_port }}
+      protocol: TCP
+      name: ws
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "bitwarden.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -24,8 +24,8 @@ bitwarden:
 
   # # Websocket support for notifications
   # # See: https://github.com/dani-garcia/bitwarden_rs#enabling-websocket-notifications
-  # # TODO: Not supported currently: Needs to be added to the ingress controller
-  # websocket_enabled: false
+  websocket_enabled: true
+  websocket_port: 3012
 
   # # Needed for U2F authentification
   # # See: https://github.com/dani-garcia/bitwarden_rs#enabling-u2f-authentication

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -159,7 +159,8 @@ ingress:
     kubernetes.io/ssl-redirect: "true"
   # className: nginx
   paths:
-    - '/'
+    - path: '/'
+      pathType: ImplementationSpecific
   hosts:
     - bitwarden.domain.tld  # host
   tls:

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -90,6 +90,10 @@ deployment:
   tolerations: []
   affinity: {}
 
+  # Passwords and sensitive data can also be provided via secrets. This can be used for ADMIN_TOKEN and SMTP_PASSWORD.
+  # Just provide the names of your secret resources that are already deployed to your namespace.
+  secrets: []
+
 securityContext:
   enabled: false
   runAsNonRoot: true


### PR DESCRIPTION
I added WebSocket support to the helm chart which is used to inform browser and desktop Bitwarden clients regarding changes. In addition, I added support for secrets to pass sensitive information via secrets and not via plaintext values.

Overall, the following changes are made:

- Make it possible to pass sensitive data via secrets (for instance, SMTP_PASSWORD and ADMIN_TOKEN)
- Add Support for WebSockets (https://github.com/dani-garcia/vaultwarden/wiki/Enabling-WebSocket-notifications)
- Fix Bug regarding capabilities retrieval in ingress resource