### PR TITLE
StorageClassName is now configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ helm delete --purge $(helm list | grep "bitwarden" | cut -f1)
 
 
 ## Configuration
-Several konfiguration options are available, they can be seen in [`values.yaml`](https://github.com/hisankaran/helm-bitwarden_rs/blob/master/charts/bitwarden/values.yaml), and override like above using `--set` or using `--values`, see more [here](https://docs.helm.sh/helm/#helm-install).
+Several konfiguration options are available, they can be seen in [`values.yaml`](https://github.com/Skeen/helm-bitwarden_rs/blob/master/charts/bitwarden/values.yaml), and override like above using `--set` or using `--values`, see more [here](https://docs.helm.sh/helm/#helm-install).
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ helm delete --purge $(helm list | grep "bitwarden" | cut -f1)
 
 
 ## Configuration
-Several konfiguration options are available, they can be seen in [`values.yaml`](https://github.com/Skeen/helm-bitwarden_rs/blob/master/values.yaml), and override like above using `--set` or using `--values`, see more [here](https://docs.helm.sh/helm/#helm-install).
+Several konfiguration options are available, they can be seen in [`values.yaml`](https://github.com/hisankaran/helm-bitwarden_rs/blob/master/charts/bitwarden/values.yaml), and override like above using `--set` or using `--values`, see more [here](https://docs.helm.sh/helm/#helm-install).
 
 ## Screenshot
 

--- a/charts/bitwarden/templates/backup-claim.yaml
+++ b/charts/bitwarden/templates/backup-claim.yaml
@@ -16,6 +16,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.backup.size }}
+  {{- if .Values.storage.className }}
+  storageClassName: {{ .Values.storage.className }}
+  {{ end }}
 status: {}
 {{- end }}
 {{- end }}

--- a/charts/bitwarden/templates/backup-claim.yaml
+++ b/charts/bitwarden/templates/backup-claim.yaml
@@ -16,8 +16,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.backup.size }}
-  {{- if .Values.storage.className }}
-  storageClassName: {{ .Values.storage.className }}
+  {{- if .Values.backup.storageClassName }}
+  storageClassName: {{ .Values.backup.storageClassName }}
   {{ end }}
 status: {}
 {{- end }}

--- a/charts/bitwarden/templates/data-claim.yaml
+++ b/charts/bitwarden/templates/data-claim.yaml
@@ -15,5 +15,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size }}
+  {{- if .Values.storage.className }}
+  storageClassName: {{ .Values.storage.className }}
+  {{ end }}
 status: {}
 {{- end }}

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -117,6 +117,8 @@ storage:
   path: "/bw-data"
   # The maximum size of the persisted data
   size: 100Mi
+  # what storge name to be used for data storage
+  # className: "gp2"
 
 
 # Settings regarding persistent backup storage

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -128,6 +128,9 @@ backup:
   # The maximum size of the persisted backup data
   size: 100Mi
 
+  # what storge name to be used for back up storage
+  # storageClassName: "gp2"
+
   # Cron schedule for the backup job (currently at 3:00 every night)
   schedule: "* 3 * * *"
 


### PR DESCRIPTION
When installing the helm chart without a pre-created PV, it times out stating [WaitForFirstConsumer PersistentVolumeClaim waiting for the first consumer to be created before binding](https://stackoverflow.com/questions/55044486/waitforfirstconsumer-persistentvolumeclaim-waiting-for-first-consumer-to-be-crea).

To avoid this, we could create a service class with `VolumeBindingMode: Immediate` and use it to create the PVC that is used for the backup job. This PR makes it possible.

PS: to avoid confusion, it would be a good idea to have a `charts` directory at https://github.com/dani-garcia/vaultwarden and update the docs. @dani-garcia @Skeen would love your thoughts.