### PR TITLE
Add support database url

### DIFF
--- a/charts/bitwarden/templates/configmap.yaml
+++ b/charts/bitwarden/templates/configmap.yaml
@@ -8,10 +8,13 @@ metadata:
     helm.sh/chart: {{ include "bitwarden.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-data: 
+data:
   {{- range $key, $val := .Values.bitwarden }}
   {{ $key | upper }}: {{ $val | quote }}
   {{- end}}
+  {{ if .Values.database.wal -}}
+  ENABLE_DB_WAL: {{ .Values.database.wal | quote }}
+  {{- end }}
   {{ if .Values.storage.enabled -}}
   DATA_FOLDER: {{ .Values.storage.path }}
   {{ end }}

--- a/charts/bitwarden/templates/configmap.yaml
+++ b/charts/bitwarden/templates/configmap.yaml
@@ -12,9 +12,7 @@ data:
   {{- range $key, $val := .Values.bitwarden }}
   {{ $key | upper }}: {{ $val | quote }}
   {{- end}}
-  {{ if .Values.database.wal -}}
   ENABLE_DB_WAL: {{ .Values.database.wal | quote }}
-  {{- end }}
   {{ if .Values.storage.enabled -}}
   DATA_FOLDER: {{ .Values.storage.path }}
   {{ end }}

--- a/charts/bitwarden/templates/deployment.yaml
+++ b/charts/bitwarden/templates/deployment.yaml
@@ -31,6 +31,14 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ $fullName }}-conf
+        {{- if or (eq .Values.database.type "mysql") (eq .Values.database.type "postgresql") }}
+        - secretRef:
+          {{- if .Values.database.existingSecret }}
+            name: {{ .Values.database.existingSecret }}
+          {{- else }}
+            name: {{ $fullName }}-database
+          {{- end }}
+        {{- end }}
         {{- if .Values.deployment.secrets }}
         {{- range .Values.deployment.secrets }}
         - secretRef:

--- a/charts/bitwarden/templates/secret.yaml
+++ b/charts/bitwarden/templates/secret.yaml
@@ -12,5 +12,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   DATABASE_URL: {{ .Values.database.url | b64enc }}
+---
 {{- end }}
 {{- end }}

--- a/charts/bitwarden/templates/secret.yaml
+++ b/charts/bitwarden/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if or (eq .Values.database.type "mysql") (eq .Values.database.type "postgresql") -}}
+{{- if not .Values.database.existingSecret -}}
+{{- $fullName := include "bitwarden.fullname" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-database
+  labels:
+    app.kubernetes.io/name: {{ include "bitwarden.name" . }}
+    helm.sh/chart: {{ include "bitwarden.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  DATABASE_URL: {{ .Values.database.url | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -73,9 +73,23 @@ bitwarden:
 
   # NOTE: HTTPS cannot be set here, as it is derived from the ingress configuration below.
   # NOTE: DATA_FOLDER cannot be set here, as it is derived from the storage.path below.
-  # TODO: Support DATABASE_URL, ATTACHMENTS_FOLDER, ICON_CACHE_FOLDER
+  # NOTE: ENABLE_DB_WAL cannot be set here, as it is derived from the database.wal below.
+  # TODO: Support ATTACHMENTS_FOLDER, ICON_CACHE_FOLDER
   # TODO: Support fail2ban?
 
+database:
+  # Database type,
+  # must be one of: 'sqlite', 'mysql' or 'postgresql'.
+  type: sqlite
+  # Enable DB Write-Ahead-Log for SQLite,
+  # disabled for other databases. https://github.com/dani-garcia/bitwarden_rs/wiki/Running-without-WAL-enabled
+  wal: true
+  # URL for external databases (mysql://user:pass@host:port/database or postgresql://user:pass@host:port/database).
+  # MySQL/MariaDB: https://github.com/dani-garcia/vaultwarden/wiki/Using-the-MariaDB-%28MySQL%29-Backend
+  # Postgresql: https://github.com/dani-garcia/vaultwarden/wiki/Using-the-PostgreSQL-Backend
+  url: ""
+  # Otherwise you can use an existing secret with key `DATABASE_URL`
+  existingSecret: null
 
 deployment:
   # Image used for the deployment
@@ -108,7 +122,7 @@ service:
 
 
 # Settings regarding persistent storage
-# TODO: Support DATABASE_URL + ATTACHMENTS_FOLDER + ICON_CACHE_FOLDER
+# TODO: Support ATTACHMENTS_FOLDER + ICON_CACHE_FOLDER
 # See: https://github.com/dani-garcia/bitwarden_rs#changing-persistent-data-location
 storage:
   # Whether storing persistent data is enabled or not


### PR DESCRIPTION
Hello to start, thanks for your work.
I have recently decided to migrate my vaultwarden instance to postgres database, so for this I have added the support to the chart.
It's very simple implementation, because I just add a secret used in `envFrom` to pass the variable `DATABASE_URL`.
This feature support a name of existing secret too for install with a secret provider.

A possibility to improve this, it's to add chart of mariadb or posgresql in dependencies like the chart of [k8s-at-home (abandoned)](https://github.com/k8s-at-home/charts/blob/master/charts/stable/vaultwarden/Chart.yaml#L18).
Personally, I never used this feature on charts, so I have no opinions on this.