### PR TITLE
Allow to override ingress annotation without merge

### DIFF
--- a/charts/bitwarden/templates/_helpers.tpl
+++ b/charts/bitwarden/templates/_helpers.tpl
@@ -30,3 +30,18 @@ Create chart name and version as used by the chart label.
 {{- define "bitwarden.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bitwarden.ingress.annotations" -}}
+{{- if .Values.ingress.annotations -}}
+{{- toYaml .Values.ingress.annotations }}
+{{- else -}}
+kubernetes.io/ingress.class: nginx
+{{- if .Values.ingress.tls }}
+kubernetes.io/tls-acme: "true"
+kubernetes.io/ssl-redirect: "true"
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/bitwarden/templates/ingress.yaml
+++ b/charts/bitwarden/templates/ingress.yaml
@@ -16,15 +16,13 @@ metadata:
     helm.sh/chart: {{ include "bitwarden.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- include "bitwarden.ingress.annotations" . | nindent 4 }}
 spec:
-{{- if .Values.ingress.tls }}
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:
@@ -33,7 +31,7 @@ spec:
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
-{{- end }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -158,10 +158,10 @@ backup:
 # Ingress configuration
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
-    kubernetes.io/ssl-redirect: "true"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ssl-redirect: "true"
   # className: nginx
   paths:
     - path: '/'


### PR DESCRIPTION
Hi, 
Like #4 I suggest removing the default ingress annotations because when pass other values helm not override them, but merge them.
I think it's for this reason that most of the others charts don't pass them, but I understand your wish to keep them by default for the backwards compatibility. 
So I just added a check if annotations are defined in values, otherwise set the default annotations.

To disable default `tls` we can just pass `ingress.tls=false` so I think it's not really a problem if it's define by default.