### PR TITLE
use new apiVersion of batch for cronjob

### DIFF
--- a/charts/bitwarden/templates/database-backup.yaml
+++ b/charts/bitwarden/templates/database-backup.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.storage.enabled -}}
 {{- if .Values.backup.enabled -}}
 {{- $fullName := include "bitwarden.fullname" . -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1"}}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ $fullName }}-database-backup


### PR DESCRIPTION
Hi, just a little update for batch `apiVersion` for cronjob to support Kubernetes server version 1.25+
> The batch/v1beta1 API version of CronJob will no longer be served in v1.25.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25